### PR TITLE
Include kubectl in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY Pipfile Pipfile.lock ./
 RUN pip install --no-cache-dir pipenv && \
     pipenv install --system --deploy --ignore-pipfile
 
+FROM alpine/kubectl:1.35.0 AS kubectl
+
 FROM python:3.14-alpine
 
 LABEL org.opencontainers.image.title="Simple KRR Dashboard" \
@@ -26,6 +28,7 @@ RUN apk add --no-cache \
 
 WORKDIR /app
 
+COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/
 COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=builder /usr/local/bin/gunicorn /usr/local/bin/gunicorn
 COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
In Helm-chart kubectl is downloaded in job and cronjob via curl (which also needs to be downloaded).
When it is already in de image, running of (cron)job is much faster, since the download of curl and kubectl is not needed anymore.

In our production-environment internet is not completely open. So these downloads are not possible. In this way kubectl is already present and usable.


<!--
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes. The PR will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

PR Steps:
1) Please make sure you test your changes before you push them.
2) Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
3) These checks run very quickly.
4) Please check the results.
5) We would like these checks to pass before we even continue reviewing your changes.
-->

#### What this PR does / why we need it:

<!--
List the things that your PR does. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

#### Which issue this PR fixes

- fixes #<issue_number>

#### Special notes for your reviewer:

<!--
Complete with your notes. If not applicable, remove this section or set N/A
-->

#### Checklist

- [ ] [DCO](https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md) signed
